### PR TITLE
Fix audio-null build / fix audio-linux build

### DIFF
--- a/audio-linux.c
+++ b/audio-linux.c
@@ -7,12 +7,13 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdbool.h>
 #include <pthread.h>
 
 #include <alsa/asoundlib.h>
 
-bool USE_AUDIO = true;
+#include "audio.h"
+
+int USE_AUDIO = 1;
 
 static pthread_mutex_t mtx = PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
@@ -20,7 +21,7 @@ static pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
 static char retro_snd_buf[16 * 1024];
 static snd_pcm_t *alsa;
 
-static bool play_retro;
+static int play_retro = 0;
 
 static void *snd_thread(void *arg)
 {
@@ -46,7 +47,7 @@ void snd_stop(void)
 		return;
 
 	pthread_mutex_lock(&mtx);
-	play_retro = false;
+	play_retro = 0;
 	snd_pcm_pause(alsa, 1);
 	pthread_mutex_unlock(&mtx);
 }
@@ -57,7 +58,7 @@ void snd_start(void)
 		return;
 
 	pthread_mutex_lock(&mtx);
-	play_retro = true;
+	play_retro = 1;
 	snd_pcm_pause(alsa, 0);
 	pthread_cond_signal(&cond);
 	pthread_mutex_unlock(&mtx);
@@ -65,7 +66,7 @@ void snd_start(void)
 
 void snd_init(void)
 {
-	int i;
+	unsigned int i;
 	int err;
 	pthread_t tid;
 	const char device[] = "plug:default";

--- a/audio-null.c
+++ b/audio-null.c
@@ -1,5 +1,8 @@
 /*
  */
+#include "audio.h"
+
+int USE_AUDIO = 0;
 
 void snd_stop(void)
 {

--- a/globals.h
+++ b/globals.h
@@ -15,8 +15,6 @@
 #ifndef _globals_h_
 #define _globals_h_
 
-#include <stdbool.h>
-
 extern Display *d;
 extern Window viewWin;
 extern Window instrWin;
@@ -33,6 +31,6 @@ extern int px, py, pz;
 extern int roll, pitch, yaw;
 extern float acceleration;
 
-extern bool USE_AUDIO;
+extern int USE_AUDIO;
 
 #endif

--- a/resource.c
+++ b/resource.c
@@ -87,7 +87,7 @@ void LoadResources (argc, argv, lander)
    XrmDatabase defaults;
    XrmValue value;
    char *type, *xrm_string;
-   int count;
+   unsigned int count;
 
    XrmInitialize ();
    defaults =
@@ -130,8 +130,6 @@ void LoadResources (argc, argv, lander)
 		       &type, &value) != True)
       XAutoRepeatOff (d);
    if (XrmGetResource (resources, "xlander.noaudio", "Xlander.NoAudio",
-		       &type, &value) == True) {
-      if (strcmp(value.addr, "true") == 0)
-         USE_AUDIO = false;
-   }
+		       &type, &value) == True)
+      USE_AUDIO = 0;
 }


### PR DESCRIPTION
Fix was required to allow audio-null to build.
Fix was required to allow audio-linux to build.
Simplified includes by using 0/1 instead of boolean false/true.
Fixed two warnings with count, i (signed vs unsigned int).